### PR TITLE
Disable read_zero_byte_vec lint

### DIFF
--- a/src/bin/wd_copier.rs
+++ b/src/bin/wd_copier.rs
@@ -94,6 +94,7 @@ fn sync_progress_bar(
     }
 }
 
+#[allow(clippy::read_zero_byte_vec)]
 fn main() {
     let opt = Opt::from_args();
 


### PR DESCRIPTION
This lint is triggering incorrectly, maybe due to:
https://github.com/rust-lang/rust-clippy/issues/9274