### PR TITLE
Remove unnecessary allow of clippy::read_zero_byte_vec

### DIFF
--- a/src/bin/wd_copier.rs
+++ b/src/bin/wd_copier.rs
@@ -90,7 +90,6 @@ fn sync_progress_bar(
     }
 }
 
-#[allow(clippy::read_zero_byte_vec)]
 fn main() {
     let opt = Opt::parse();
 


### PR DESCRIPTION
This lint used to incorrectly trigger here, but it no longer does.