### PR TITLE
Rename UsbBlockDevice::summary to full_name

### DIFF
--- a/src/bin/writedisk.rs
+++ b/src/bin/writedisk.rs
@@ -83,7 +83,7 @@ impl UsbBlockDevice {
         Ok(result)
     }
 
-    fn summary(&self) -> String {
+    fn full_name(&self) -> String {
         format!("{} {} {}", &self.manufacturer, &self.product, &self.serial)
     }
 }
@@ -100,7 +100,7 @@ fn choose_device() -> UsbBlockDevice {
         println!(
             "{index}: [{path}] {name}",
             path = device.path.display(),
-            name = device.summary()
+            name = device.full_name()
         );
     }
 

--- a/src/bin/writedisk.rs
+++ b/src/bin/writedisk.rs
@@ -84,13 +84,7 @@ impl UsbBlockDevice {
     }
 
     fn summary(&self) -> String {
-        format!(
-            "[{}] {} {} {}",
-            self.path.display(),
-            &self.manufacturer,
-            &self.product,
-            &self.serial,
-        )
+        format!("{} {} {}", &self.manufacturer, &self.product, &self.serial)
     }
 }
 
@@ -103,7 +97,11 @@ fn choose_device() -> UsbBlockDevice {
     }
 
     for (index, device) in devices.iter().enumerate() {
-        println!("{index}: {}", device.summary());
+        println!(
+            "{index}: [{path}] {name}",
+            path = device.path.display(),
+            name = device.summary()
+        );
     }
 
     print!("select device: ");


### PR DESCRIPTION
The full_name method no longer includes the path, just the immutable parts of the device name. This is in preparation for adding a program option to automatically use a particular USB device by name.